### PR TITLE
Remove unsupported INTERFACE library catkin export

### DIFF
--- a/scout_base/CMakeLists.txt
+++ b/scout_base/CMakeLists.txt
@@ -25,7 +25,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES scout_messenger
   CATKIN_DEPENDS ugv_sdk scout_msgs tf tf2 tf2_ros
 #   DEPENDS Boost
 )


### PR DESCRIPTION
Catkin does not allow exporting `INTERFACE` libraries. This export makes `catkin_make_isolated` fail.